### PR TITLE
npm install gulp-sass error

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "gulp-load-plugins": "^0.8.0",
     "gulp-minify-html": "^0.1.8",
     "gulp-replace": "^0.5.0",
-    "gulp-sass": "^1.2.2",
+    "gulp-sass": "^2.1.1",
     "gulp-size": "^1.0.0",
     "gulp-uglify": "^1.0.1",
     "gulp-uncss": "^0.5.2",


### PR DESCRIPTION
Many of us have tried running `npm install` and every time we do the gulp-sass fails to build and we get a serve error when we run `gulp serve` so running 

```
npm uninstall --save-dev gulp-sass
npm install --save-dev gulp-sass@2
```

Fixed the problems. Instead of people needing to search for the solution thought we would fix the bug by changing the gulp-sass version.
