### PR TITLE
update gulp-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "gulp-load-plugins": "^0.8.0",
     "gulp-minify-html": "^0.1.8",
     "gulp-replace": "^0.5.0",
-    "gulp-sass": "^2.1.1",
+    "gulp-sass": "^3.2.1",
     "gulp-size": "^1.0.0",
     "gulp-uglify": "^1.0.1",
     "gulp-uncss": "^0.5.2",


### PR DESCRIPTION
With the old version of gulp-sass, `npm install` runs into an error.
For further details, see this [udacity discourse thread](https://discussions.udacity.com/t/gulp-install-error/225044?u=dreamerkiwi).