### PR TITLE
Deprecated: createObjectURL

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -244,7 +244,7 @@
           cb(videoSource);
         };
 
-        cameraVideo.src = window.URL.createObjectURL(localStream);
+        cameraVideo.srcObject = localStream;
         cameraVideo.load();
         cameraVideo.play();
       }, function(error) {});

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -311,7 +311,7 @@
       if(document.visibilityState === 'hidden') {
         // Disconnect the camera.
         if(localStream !== undefined) {
-          localStream.stop();
+          localStream.getVideoTracks()[0].stop();
           localStream = undefined;
         }
       }


### PR DESCRIPTION
window.URL.createObjectURL() is deprecated, use .srcObject = stream instead